### PR TITLE
[감하영] products_volume 테이블 & carts 테이블을 1대다로 수정

### DIFF
--- a/prisma/migrations/20210714073249_add_cart_product_volume_id/migration.sql
+++ b/prisma/migrations/20210714073249_add_cart_product_volume_id/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `product_id` on the `carts` table. All the data in the column will be lost.
+  - Added the required column `product_volume_id` to the `carts` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE `carts` DROP FOREIGN KEY `carts_ibfk_1`;
+
+-- AlterTable
+ALTER TABLE `carts` DROP COLUMN `product_id`,
+    ADD COLUMN `product_volume_id` INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `carts` ADD FOREIGN KEY (`product_volume_id`) REFERENCES `products_volume`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model ProductVolume {
   products  Product  @relation(fields: [productId], references: [id])
   volume    Volume   @relation(fields: [volumeId], references: [id])
 
+  Cart Cart[]
   @@map("products_volume")
 }
 
@@ -71,7 +72,6 @@ model Product {
   images           Image[]
   productsKeywords ProductKeyword[]
   reviews          Review[]
-  cart             Cart[]
 
   @@map("products")
 }
@@ -178,14 +178,14 @@ model ReviewImage {
 }
 
 model Cart {
-  id        Int      @id @default(autoincrement())
-  quantity  Int      @default(1)
-  userId    Int      @map("user_id")
-  productId Int      @map("product_id")
-  createdAt DateTime @default(now()) @map("created_at")
+  id              Int      @id @default(autoincrement())
+  quantity        Int      @default(1)
+  userId          Int      @map("user_id")
+  productVolumeId Int      @map("product_volume_id")
+  createdAt       DateTime @default(now()) @map("created_at")
 
-  products Product @relation(fields: [productId], references: [id])
-  users    User    @relation(fields: [userId], references: [id])
+  users         User          @relation(fields: [userId], references: [id])
+  productVolume ProductVolume @relation(fields: [productVolumeId], references: [id])
 
   @@map("carts")
 }


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약

- ProductVolume 모델과 Cart 모델을 1대다 관계로 수정

## 수정 사항들 자세한 내용

- Cart 모델에서 productId를 삭제
- Cart 모델에 productVolumeId를 추가

![image](https://user-images.githubusercontent.com/50080535/125585612-2c329898-20b7-42b2-b3bd-d2cfa1ba3c17.png)


## 기타 질문 및 특이 사항

ProductVolume 테이블과 Cart 테이블의 연결 관계는 1대다라고 생각했는데 1대1인건 아닌지 혼란스럽습니다🥲
먼저 1대다라고 생각한 이유는 다음과 같습니다.
- ProductVolume 테이블이 one, Cart 테이블이 many
- ProductVolume 테이블의 row 하나는 Cart 테이블의 여러 row와 연결
   - 장바구니에 같은 상품을 여러 유저가 담을 수 있기 때문
- Cart 테이블의 row 하나는 ProductVolume 테이블의 row 하나와 연결
   - 카트의 한 상품은 ProductVolume 테이블의 상품 하나와 연결됨)

## 체크 리스트

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
