### PR TITLE
[감하영] ProductKeyword model에 grade 컬럼 추가

### DIFF
--- a/prisma/migrations/20210720144123_add_grade_in_product_keyword_model/migration.sql
+++ b/prisma/migrations/20210720144123_add_grade_in_product_keyword_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `grade` to the `products_keywords` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `products_keywords` ADD COLUMN `grade` VARCHAR(20) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,6 +130,7 @@ model ProductKeyword {
   id        Int      @id @default(autoincrement())
   productId Int      @map("product_id")
   keywordId Int      @map("keyword_id")
+  grade     String   @db.VarChar(20)
   createdAt DateTime @default(now()) @map("created_at")
   products  Product  @relation(fields: [productId], references: [id])
   keywords  Keyword  @relation(fields: [keywordId], references: [id])


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
- ProductKeyword model에 grade 컬럼 추가
		 
## 수정 사항들 자세한 내용

- [상세페이지 리팩토링 과정](https://github.com/wecode-bootcamp-korea/fullstack1-1st-BaseNote-frontend/pull/24#discussion_r672805318)에서 Keyword 부분의 목데이터를 수정하게 되었고 그에 맞춰 모델을 수정하게 되었습니다.
- 상세페이지의 Keyword 영역(아래 캡쳐)에서 향수의 12개 키워드 중 3개씩 그룹(같은 레벨)을 이루어 출력해야할 필요로 인해 grade를 추가하게 되었습니다.
- grade 칼럼을 중간 테이블인 products_keywords에 바로 추가해보았습니다.

![image](https://user-images.githubusercontent.com/50080535/126349872-350b1aea-fa57-45a0-a0b1-a1f5f7103f2c.png)

## 기타 질문 및 특이 사항

- grade 테이블을 별도로 만들어준 후, products_keywords 테이블에서 FK로 grade_id를 사용하는 방법과 고민했으나, 테이블을 별도로 빼주면 JOIN을 하는 과정에서의 번거로움과 테이블이 너무 많아지면 관리에 까다롭지 않을까라는 생각에 products_keywords에 바로 추가하는 방법을 선택했습니다만, 이 방법이 올바른 방법인지 궁금합니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
